### PR TITLE
feat: Add Image Extractor

### DIFF
--- a/src-rust/Cargo.lock
+++ b/src-rust/Cargo.lock
@@ -826,6 +826,7 @@ name = "fosscopetoolkit-core"
 version = "0.1.0-dev"
 dependencies = [
  "html2md",
+ "kuchiki",
  "libhtmlfilter",
  "octocrab",
  "regex",
@@ -2997,6 +2998,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.5",

--- a/src-rust/toolkit-core/Cargo.toml
+++ b/src-rust/toolkit-core/Cargo.toml
@@ -19,10 +19,11 @@ serde = { version = "1", features = ["derive"] } # Serialization
 serde_json = "1.0.117" # JSON Serialization
 toml = "0.8.14" # TOML Serialization
 regex = "1.10.5" # Regular Expression
-reqwest = { version = "0.12", features = ["json"] } # HTTP Client
+reqwest = { version = "0.12", features = ["json","blocking"] } # HTTP Client
 octocrab = "0.38.0" # GitHub API
 html2md = { workspace = true } # HTML to Markdown
 libhtmlfilter = "0.1.0" # HTML Filter
+kuchiki = "0.8.1"
 
 [dev-dependencies]
 wiremock = "0.6.0"

--- a/src-rust/toolkit-core/Cargo.toml
+++ b/src-rust/toolkit-core/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] } # Serialization
 serde_json = "1.0.117" # JSON Serialization
 toml = "0.8.14" # TOML Serialization
 regex = "1.10.5" # Regular Expression
-reqwest = { version = "0.12", features = ["json","blocking"] } # HTTP Client
+reqwest = { version = "0.12", features = ["json", "blocking"] } # HTTP Client
 octocrab = "0.38.0" # GitHub API
 html2md = { workspace = true } # HTML to Markdown
 libhtmlfilter = "0.1.0" # HTML Filter

--- a/src-rust/toolkit-core/src/parser/image_extractor.rs
+++ b/src-rust/toolkit-core/src/parser/image_extractor.rs
@@ -1,0 +1,41 @@
+use reqwest::blocking::get;
+use kuchiki::traits::*;
+use std::fs::{File, create_dir_all};
+use std::io::copy;
+use std::path::Path;
+
+/* 
+    Download images from an HTML string based on specified file extensions.
+
+    # Arguments
+    * `html` - A string slice that holds the HTML content to be parsed.
+    * `extensions` - A string slice that contains comma-separated file extensions (e.g., "jpg,png").
+    * `path` - A string slice that represents the directory where the images will be saved.
+*/
+pub fn download_images(html: &str, extensions: &str, path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let extensions: Vec<&str> = extensions.split(',').collect();
+    let document = kuchiki::parse_html().one(html);
+
+    if !Path::new(path).exists() {
+        create_dir_all(path)?;
+    }
+
+    for img_node in document.select("img").unwrap() {
+        let img_element = img_node.as_node().as_element().unwrap();
+        if let Some(src) = img_element.attributes.borrow().get("src") {
+            if let Some(extension) = Path::new(src).extension() {
+                if let Some(extension_str) = extension.to_str() {
+                    if extensions.contains(&extension_str) {
+                        let response = get(src)?;
+                        let filename = Path::new(src).file_name().unwrap();
+                        let target_path = Path::new(path).join(filename);
+                        let mut file = File::create(target_path)?;
+                        copy(&mut response.bytes()?.as_ref(), &mut file)?;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src-rust/toolkit-core/src/parser/mod.rs
+++ b/src-rust/toolkit-core/src/parser/mod.rs
@@ -1,3 +1,5 @@
 mod html_to_markdown;
+mod image_extractor;
 
 pub use html_to_markdown::html_to_markdown;
+pub use image_extractor::download_images;


### PR DESCRIPTION
Added module "image_extractor.rs" that filters and saves images from the original article to a specified local directory based on their file extensions.